### PR TITLE
Feature/e2e testing details page

### DIFF
--- a/cypress/fixtures/MulanDetails.json
+++ b/cypress/fixtures/MulanDetails.json
@@ -1,0 +1,22 @@
+{
+    "movie": 
+        {
+            "id": 337401,
+            "title": "Mulan",
+            "poster_path": "https://image.tmdb.org/t/p/original//aKx1ARwG55zZ0GpRvU2WrGrCG9o.jpg",
+            "backdrop_path": "https://image.tmdb.org/t/p/original//zzWGRw277MNoCs3zhyG3YmYQsXv.jpg",
+            "release_date": "2020-09-04",
+            "overview": "When the Emperor of China issues a decree that one man per family must serve in the Imperial Chinese Army to defend the country from Huns, Hua Mulan, the eldest daughter of an honored warrior, steps in to take the place of her ailing father. She is spirited, determined and quick on her feet. Disguised as a man by the name of Hua Jun, she is tested every step of the way and must harness her innermost strength and embrace her true potential.",
+            "genres": [
+                "Action",
+                "Adventure",
+                "Drama",
+                "Fantasy"
+                ],
+            "budget": 200000000,
+            "revenue": 57000000,
+            "runtime": 115,
+            "tagline": "",
+            "average_rating": 5.1
+        }
+}

--- a/cypress/integration/1-getting-started/detailsPage.spec.js
+++ b/cypress/integration/1-getting-started/detailsPage.spec.js
@@ -8,7 +8,7 @@ describe('Details view page', () => {
         cy.get('.movie-container > div').eq(1).click();
     })
 
-    // SAD PATHS
+    // SAD PATHS for our details page load
     it('Should display an error message on failed API load for details page - 500', () => {
       cy.intercept({
           method: 'GET', 
@@ -23,7 +23,7 @@ describe('Details view page', () => {
       .get('.error-msg').should('contain', 'Network Error - status 500')
     })
 
-    it.only('Should display an error message on failed API load for details page - 404', () => {
+    it('Should display an error message on failed API load for details page - 404', () => {
         cy.intercept({
             method: 'GET', 
             url: 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/666'
@@ -33,6 +33,36 @@ describe('Details view page', () => {
             statusCode: 404,
             body: {
                 message: `Cannot GET /api/v2/movies/666`
+            }
+        })
+        .get('.error-msg').should('contain', 'Network Error - status 404')
+    })
+
+    // SAD PATHS for our video load
+    it('Should display an error message on failed API load for videos - 500', () => {
+      cy.intercept({
+          method: 'GET', 
+          url: 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/337401/videos'
+      },
+      {
+          statusCode: 500,
+          body: {
+              message: `Network Error - status 500 at URL: https://rancid-tomatillos.herokuapp.com/api/v2/movies/337401/videos`
+          }
+      })
+      .get('.error-msg').should('contain', 'Network Error - status 500')
+    })
+
+    it('Should display an error message on failed API load for details page - 404', () => {
+        cy.intercept({
+            method: 'GET', 
+            url: 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/666/videos'
+
+        },
+        {
+            statusCode: 404,
+            body: {
+                message: `Cannot GET /api/v2/movies/666/videos`
             }
         })
         .get('.error-msg').should('contain', 'Network Error - status 404')

--- a/cypress/integration/1-getting-started/detailsPage.spec.js
+++ b/cypress/integration/1-getting-started/detailsPage.spec.js
@@ -1,37 +1,50 @@
 describe('Details view page', () => {
 
     beforeEach( () => {
+        cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies', { fixture: 'movieData.json' })
+        cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/337401', { fixture: 'mulanDetails.json' })
         cy.visit('http://localhost:3000/')
+        cy.wait(2000)
         cy.get('.movie-container > div').eq(1).click();
-        cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/337401', { 'fixture: MulanDetails' })
     })
 
-    it('Should visit movie details page', () => {
-        cy.get('div')
+    it('Should see movie title, movie description, and play button in movie player box', () => {
+        cy.get('.showcase-content').contains('Mulan')
+        cy.get('.showcase-content').contains('When the Emperor of China issues a decree that one man per family must serve in the Imperial Chinese Army to defend the country from Huns')
     })
 
+    it('Should be able to play a movie preview', () => {
+        cy.get('.btn').click()
+        cy.get('iframe').should('have.attr', 'src').should('include', 'https://www.youtube.com/embed/01ON04GCwKs')
+    })
 
-    // it('Should have a title', () => {
-    //     cy.contains('RANCID TOMATILLOS')
-    // })
+    it('Should load movie poster', () => {
+        cy.get('.details-content').find('img').should('have.attr', 'src').should('include', 'https://image.tmdb.org/t/p/original//aKx1ARwG55zZ0GpRvU2WrGrCG9o.jpg')
+    })
 
-    // it('Should have a home button', () => {
-    //     cy.get('button').contains('HOME')
-    // }) 
+    it('Should display a list of movie details', () => {
+        cy.get('article')
+          .should('contain.text', 'Mulan (2020)')
 
-    // it('Should have a genre drop down menu with different genres displayed', () => {
-    //     cy.get('button').contains('GENRE')
-    //     cy.get('.dropdown > .nav-btn').trigger('mouseover').get('.dropdown-content').contains('ACTION')
-    //     cy.get('.dropdown > .nav-btn').trigger('mouseover').get('.dropdown-content').contains('ADVENTURE')
-    //     cy.get('.dropdown > .nav-btn').trigger('mouseover').get('.dropdown-content').contains('HORROR')
-    //     cy.get('.dropdown > .nav-btn').trigger('mouseover').get('.dropdown-content').contains('COMEDY')
-    // })
+        cy.get('article')
+          .should('contain.text', 'Release Date: 2020/09/04')
 
-    // it('Should be able to input a text and display a movie poster', () => {
-    //     cy.get('input[name="search"]')
-    //     .type('Rogue')
+        cy.get('article')
+          .should('contain.text', 'Runtime: 115 minutes')
 
-    //     cy.get('[alt="Rogue movie poster"]')
-    //     .should('be.visible')
-    // })
+        cy.get('article')
+          .should('contain.text', 'Genre: Action,Adventure,Drama,Fantasy')
+
+        cy.get('article')
+          .should('contain.text', 'Budget: $200000000.00')
+
+        cy.get('article')
+          .should('contain.text', 'Revenue: $57000000.00')
+    })
+
+    it('Should return home when home button clicked', () => {
+        cy.get('.home-btn').click();
+        cy.url().should('eq', 'http://localhost:3000/') // more precise
+        // cy.url().should('include', 'http://localhost:3000/')
+    })
 })

--- a/cypress/integration/1-getting-started/detailsPage.spec.js
+++ b/cypress/integration/1-getting-started/detailsPage.spec.js
@@ -1,0 +1,37 @@
+describe('Details view page', () => {
+
+    beforeEach( () => {
+        cy.visit('http://localhost:3000/')
+        cy.get('.movie-container > div').eq(1).click();
+        cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/337401', { 'fixture: MulanDetails' })
+    })
+
+    it('Should visit movie details page', () => {
+        cy.get('div')
+    })
+
+
+    // it('Should have a title', () => {
+    //     cy.contains('RANCID TOMATILLOS')
+    // })
+
+    // it('Should have a home button', () => {
+    //     cy.get('button').contains('HOME')
+    // }) 
+
+    // it('Should have a genre drop down menu with different genres displayed', () => {
+    //     cy.get('button').contains('GENRE')
+    //     cy.get('.dropdown > .nav-btn').trigger('mouseover').get('.dropdown-content').contains('ACTION')
+    //     cy.get('.dropdown > .nav-btn').trigger('mouseover').get('.dropdown-content').contains('ADVENTURE')
+    //     cy.get('.dropdown > .nav-btn').trigger('mouseover').get('.dropdown-content').contains('HORROR')
+    //     cy.get('.dropdown > .nav-btn').trigger('mouseover').get('.dropdown-content').contains('COMEDY')
+    // })
+
+    // it('Should be able to input a text and display a movie poster', () => {
+    //     cy.get('input[name="search"]')
+    //     .type('Rogue')
+
+    //     cy.get('[alt="Rogue movie poster"]')
+    //     .should('be.visible')
+    // })
+})

--- a/cypress/integration/1-getting-started/detailsPage.spec.js
+++ b/cypress/integration/1-getting-started/detailsPage.spec.js
@@ -8,6 +8,36 @@ describe('Details view page', () => {
         cy.get('.movie-container > div').eq(1).click();
     })
 
+    // SAD PATHS
+    it('Should display an error message on failed API load for details page - 500', () => {
+      cy.intercept({
+          method: 'GET', 
+          url: 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/337401'
+      },
+      {
+          statusCode: 500,
+          body: {
+              message: `Network Error - status 500 at URL: https://rancid-tomatillos.herokuapp.com/api/v2/movies/337401`
+          }
+      })
+      .get('.error-msg').should('contain', 'Network Error - status 500')
+    })
+
+    it.only('Should display an error message on failed API load for details page - 404', () => {
+        cy.intercept({
+            method: 'GET', 
+            url: 'https://rancid-tomatillos.herokuapp.com/api/v2/movies/666'
+
+        },
+        {
+            statusCode: 404,
+            body: {
+                message: `Cannot GET /api/v2/movies/666`
+            }
+        })
+        .get('.error-msg').should('contain', 'Network Error - status 404')
+    })
+
     it('Should see movie title, movie description, and play button in movie player box', () => {
         cy.get('.showcase-content').contains('Mulan')
         cy.get('.showcase-content').contains('When the Emperor of China issues a decree that one man per family must serve in the Imperial Chinese Army to defend the country from Huns')

--- a/cypress/integration/1-getting-started/detailsPage.spec.js
+++ b/cypress/integration/1-getting-started/detailsPage.spec.js
@@ -22,7 +22,7 @@ describe('Details view page', () => {
         cy.get('.details-content').find('img').should('have.attr', 'src').should('include', 'https://image.tmdb.org/t/p/original//aKx1ARwG55zZ0GpRvU2WrGrCG9o.jpg')
     })
 
-    it('Should display a list of movie details', () => {
+    it('Should display a list of movie details', () => { // chain .should
         cy.get('article')
           .should('contain.text', 'Mulan (2020)')
 

--- a/cypress/integration/1-getting-started/landingPage.spec.js
+++ b/cypress/integration/1-getting-started/landingPage.spec.js
@@ -5,8 +5,23 @@ describe('Landing Page', () => {
         cy.visit('http://localhost:3000/')
     })
 
-    // Test API
-    it.only('Should display an error message on failed API load', () => {
+    // FINISH AFTER ROUTER
+    it.skip('Should load api and return 200 status', () => {
+        cy.intercept({
+            method: 'GET', 
+            url: 'https://rancid-tomatillos.herokuapp.com/api/v2/movies'
+        },
+        {
+            statusCode: 200,
+            body: {
+                message: `Network Error - status 500 at URL: https://rancid-tomatillos.herokuapp.com/api/v2/movies`
+            }
+        })
+        .get('.error-msg').should('contain', 'Network Error - status 500')
+    })
+
+    // SAD PATHS
+    it('Should display an error message on failed API load - 500', () => {
         cy.intercept({
             method: 'GET', 
             url: 'https://rancid-tomatillos.herokuapp.com/api/v2/movies'
@@ -18,6 +33,21 @@ describe('Landing Page', () => {
             }
         })
         .get('.error-msg').should('contain', 'Network Error - status 500')
+    })
+
+    it.only('Should display an error message on failed API load - 404', () => {
+        cy.intercept({
+            method: 'GET', 
+            url: 'https://rancid-tomatillos.herokuapp.com/api/v2/moviesbittermelon'
+
+        },
+        {
+            statusCode: 404,
+            body: {
+                message: `Cannot GET /api/v2/moviesbittermelon`
+            }
+        })
+        .get('.error-msg').should('contain', 'Network Error - status 404')
     })
 
     it('Should have a title', () => {

--- a/cypress/integration/1-getting-started/landingPage.spec.js
+++ b/cypress/integration/1-getting-started/landingPage.spec.js
@@ -1,8 +1,8 @@
 describe('Landing Page', () => {
 
     beforeEach( () => {
-        cy.visit('http://localhost:3000/')
         cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies', { fixture: 'movieData.json' })
+        cy.visit('http://localhost:3000/')
     })
 
     it('Should have a title', () => {

--- a/cypress/integration/1-getting-started/landingPage.spec.js
+++ b/cypress/integration/1-getting-started/landingPage.spec.js
@@ -1,7 +1,7 @@
 describe('Landing Page', () => {
 
     beforeEach( () => {
-        cy.fixture('./MovieData.json').as('MovieData')
+        cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies', { fixture: 'movieData.json' })
         cy.visit('http://localhost:3000/')
     })
 
@@ -30,8 +30,7 @@ describe('Landing Page', () => {
     })
 
     it('Should be able to input a text and display a movie poster', () => {
-        cy.get('input[name="search"]')
-        .type('Rogue')
+        cy.get('input[name="search"]').type('Rogue')
 
         cy.get('[alt="Rogue movie poster"]')
         .should('be.visible')

--- a/cypress/integration/1-getting-started/landingPage.spec.js
+++ b/cypress/integration/1-getting-started/landingPage.spec.js
@@ -5,6 +5,21 @@ describe('Landing Page', () => {
         cy.visit('http://localhost:3000/')
     })
 
+    // Test API
+    it.only('Should display an error message on failed API load', () => {
+        cy.intercept({
+            method: 'GET', 
+            url: 'https://rancid-tomatillos.herokuapp.com/api/v2/movies'
+        },
+        {
+            statusCode: 500,
+            body: {
+                message: `Network Error - status 500 at URL: https://rancid-tomatillos.herokuapp.com/api/v2/movies`
+            }
+        })
+        .get('.error-msg').should('contain', 'Network Error - status 500')
+    })
+
     it('Should have a title', () => {
         cy.contains('RANCID TOMATILLOS')
     })
@@ -63,6 +78,7 @@ describe('Landing Page', () => {
     it('Should not show any movies if the user searches for a movie title that doesn"t exist', () => {
         cy.get('input[name="search"]').type('The Great')
         cy.get('div[class="movie-container"]').children().should('have.length', 0)
+        // Check error message string
     })
     
     it('Should redisplay all movies when a user clicks home', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-player": "^2.10.1",
+        "react-router-dom": "^5.3.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       },
@@ -8820,6 +8821,32 @@
         "he": "bin/he"
       }
     },
+    "node_modules/history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/hoopy": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
@@ -14629,6 +14656,74 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.1.tgz",
+      "integrity": "sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=15"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.0.tgz",
+      "integrity": "sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.1",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=15"
+      }
+    },
+    "node_modules/react-router/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "node_modules/react-router/node_modules/mini-create-react-context": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "tiny-warning": "^1.0.3"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.0.0",
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/react-router/node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/react-router/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -14944,6 +15039,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "node_modules/resolve-url-loader": {
       "version": "4.0.0",
@@ -16287,6 +16387,16 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "node_modules/tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -16668,6 +16778,11 @@
       "engines": {
         "node": ">=10.12.0"
       }
+    },
+    "node_modules/value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -23914,6 +24029,34 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
     "hoopy": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
@@ -27975,6 +28118,66 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
     },
+    "react-router": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.1.tgz",
+      "integrity": "sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "mini-create-react-context": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+          "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+          "requires": {
+            "@babel/runtime": "^7.12.1",
+            "tiny-warning": "^1.0.3"
+          }
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.0.tgz",
+      "integrity": "sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.1",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -28217,6 +28420,11 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url-loader": {
       "version": "4.0.0",
@@ -29220,6 +29428,16 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
+    "tiny-invariant": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -29506,6 +29724,11 @@
         "convert-source-map": "^1.6.0",
         "source-map": "^0.7.3"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-player": "^2.10.1",
+    "react-router-dom": "^5.3.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -26,8 +26,8 @@ class App extends Component {
 
   componentDidMount = () => {
     // fetch('https://httpstat.us/500') 
-    fetch('https://rancid-tomatillos.herokuapp.com/api/v2/moviesbittermelon') 
-    // fetch('https://rancid-tomatillos.herokuapp.com/api/v2/movies')
+    // fetch('https://rancid-tomatillos.herokuapp.com/api/v2/moviesbittermelon') 
+    fetch('https://rancid-tomatillos.herokuapp.com/api/v2/movies')
     .then(response => {
       if(!response.ok) {
         console.log('HTTP request unsuccessful');

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -60,7 +60,7 @@ class App extends Component {
       return(
         <main className='app-main'>
           <NavBar goHome={ this.goHome } handleChange={ this.handleChange }/>
-          <h1>{this.state.error}</h1>
+          <h2 className='error-msg'>{this.state.error}</h2>
           {/* <Switch> */}
           {/* <Route exact path="/" component={() => <MovieContainer movies={ this.state.movies } loadMovieDetails={ this.loadMovieDetails } />} /> */}
           {/* </Switch> */}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,9 +1,17 @@
 import React, {Component} from 'react';
+import { Route, Switch, Link } from 'react-router-dom';
 import MovieContainer from './MovieContainer';
 import MovieDetailsContainer from './MovieDetailsContainer';
-// import movieData from '../movieData';
 import NavBar from './NavBar';
 import '../styles/App.css';
+
+const Pizza = () => {
+  return (
+    <div>
+      <h2>PIZZA PIZZA PIZZA</h2>
+    </div>
+  )
+}
 
 class App extends Component {
   constructor() {
@@ -50,15 +58,18 @@ class App extends Component {
 
   render() {
       return(
-        <main className='container'>
-          <NavBar goHome={this.goHome} handleChange={ this.handleChange }/>
+        <main className='app-main'>
+          <NavBar goHome={ this.goHome } handleChange={ this.handleChange }/>
           <h1>{this.state.error}</h1>
-
+          {/* <Switch> */}
+          {/* <Route exact path="/" component={() => <MovieContainer movies={ this.state.movies } loadMovieDetails={ this.loadMovieDetails } />} /> */}
+          {/* </Switch> */}
           {/* If there is no search, then load all movies */}
+          <Route exact path="/pizza" component={Pizza}/>
           {(!Object.keys(this.state.currentMovie).length 
             && Object.keys(this.state.movies).length 
             && !Object.keys(this.state.searchedMovies).length)
-            && <MovieContainer movies={this.state.movies} loadMovieDetails={ this.loadMovieDetails } /> 
+            && <Route exact path="/" component={() => <MovieContainer movies={ this.state.movies } loadMovieDetails={ this.loadMovieDetails } />} /> 
           }
 
           {/* Load search results instead */}
@@ -74,3 +85,29 @@ class App extends Component {
 }
 
 export default App;
+
+
+// render() {
+//   return(
+//     <main className='app-main'>
+//       <NavBar goHome={this.goHome} handleChange={ this.handleChange }/>
+//       <h1>{this.state.error}</h1>
+
+//       {/* If there is no search, then load all movies */}
+//       {(!Object.keys(this.state.currentMovie).length 
+//         && Object.keys(this.state.movies).length 
+//         && !Object.keys(this.state.searchedMovies).length)
+//         && <MovieContainer movies={this.state.movies} loadMovieDetails={ this.loadMovieDetails } /> 
+//       }
+
+//       {/* Load search results instead */}
+//       {(!Object.keys(this.state.currentMovie).length && Object.keys(this.state.searchedMovies).length) 
+//         && <MovieContainer movies={this.state.searchedMovies} loadMovieDetails={ this.loadMovieDetails } /> 
+//       }
+      
+//       {/* Page load on user clicking on a poster */}
+//       {Object.keys(this.state.currentMovie).length && <MovieDetailsContainer movieId={ this.state.currentMovie.id } />}
+//     </main>
+//   )
+// }
+// }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -25,8 +25,9 @@ class App extends Component {
   }
 
   componentDidMount = () => {
-    // fetch('https://httpstat.us/500')
-    fetch('https://rancid-tomatillos.herokuapp.com/api/v2/movies')
+    // fetch('https://httpstat.us/500') 
+    fetch('https://rancid-tomatillos.herokuapp.com/api/v2/moviesbittermelon') 
+    // fetch('https://rancid-tomatillos.herokuapp.com/api/v2/movies')
     .then(response => {
       if(!response.ok) {
         console.log('HTTP request unsuccessful');

--- a/src/components/MovieDetailsContainer.js
+++ b/src/components/MovieDetailsContainer.js
@@ -42,8 +42,8 @@ class MovieDetailsContainer extends Component {
       return response;
     })
     .then(response => response.json())
-    // .then(movieDetails => this.setState({ currentMovieVideos: movieDetails }))
-    // .catch(err => console.log(err));
+    .then(movieDetails => this.setState({ currentMovieVideos: movieDetails }))
+    .catch(err => console.log(err));
   }
 
   componentDidMount = () => {

--- a/src/components/MovieDetailsContainer.js
+++ b/src/components/MovieDetailsContainer.js
@@ -11,7 +11,6 @@ class MovieDetailsContainer extends Component {
       error: ''
     }
   }
-
   
   getMovieResponse = (url) => {
     fetch(url)
@@ -56,7 +55,7 @@ class MovieDetailsContainer extends Component {
   render() {
     return (
       <div className='movie-details-container'>
-        {Object.keys(this.state.currentMovieDetails).length && <MovieDetails movieDetails={ this.state.currentMovieDetails } movieVideos={ this.state.currentMovieVideos} />}
+        {Object.keys(this.state.currentMovieDetails).length && Object.keys(this.state.currentMovieVideos).length && <MovieDetails movieDetails={ this.state.currentMovieDetails } movieVideos={ this.state.currentMovieVideos} />}
       </div>
     )
   }

--- a/src/components/MovieDetailsContainer.js
+++ b/src/components/MovieDetailsContainer.js
@@ -13,7 +13,9 @@ class MovieDetailsContainer extends Component {
   }
   
   getMovieResponse = (url) => {
-    fetch(url)
+    // fetch(url)
+    // fetch('https://httpstat.us/500') 
+    fetch('https://rancid-tomatillos.herokuapp.com/api/v2/moviesbittermelon') 
     .then(response => {
       if(!response.ok) {
         console.log('HTTP request unsuccessful');
@@ -55,6 +57,7 @@ class MovieDetailsContainer extends Component {
   render() {
     return (
       <div className='movie-details-container'>
+        <h2 className='error-msg'>{this.state.error}</h2>
         {Object.keys(this.state.currentMovieDetails).length && Object.keys(this.state.currentMovieVideos).length && <MovieDetails movieDetails={ this.state.currentMovieDetails } movieVideos={ this.state.currentMovieVideos} />}
       </div>
     )

--- a/src/components/MovieDetailsContainer.js
+++ b/src/components/MovieDetailsContainer.js
@@ -13,9 +13,9 @@ class MovieDetailsContainer extends Component {
   }
   
   getMovieResponse = (url) => {
-    // fetch(url)
     // fetch('https://httpstat.us/500') 
-    fetch('https://rancid-tomatillos.herokuapp.com/api/v2/moviesbittermelon') 
+    // fetch('https://rancid-tomatillos.herokuapp.com/api/v2/moviesbittermelon') 
+    fetch(url)
     .then(response => {
       if(!response.ok) {
         console.log('HTTP request unsuccessful');
@@ -32,11 +32,13 @@ class MovieDetailsContainer extends Component {
   }
 
   getVideoResponse = (url) => {
+    // fetch('https://httpstat.us/500') 
+    // fetch('https://rancid-tomatillos.herokuapp.com/api/v2/movies/666/videos') 
     fetch(url)
     .then(response => {
       if(!response.ok) {
         console.log('HTTP request unsuccessful');
-        this.setState({error: `Network Error - status ${response.status} at URL: ${response.url}`});
+        this.setState({error: `Network Error - status ${response.status} at URL: ${response.url} for videos`});
         throw new Error(`status ${response.status} at URL: ${response.url}`)
       } else {
         console.log('HTTP request successful');

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './components/App';
 
+import { BrowserRouter } from 'react-router-dom';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Description 
We've implemented more end-to-end (E2E) testing for the get movie details page and sad path network requests. Currently our sad path tests work, but not independently with just Cypress. We hope once we implement router, we'll be able to use more accessible end points. 

#### Where to start?
Open up the repository and go to the following:
`cypress --> integration --> detailsPage.spec.js` to see all tests for the details page and respective network tests
`cypress --> integration --> landingPage.spec.js` to see all tests for the landing page and added respective network tests

#### How to test?
In the project directory, you can run:

### `npm start`
Runs the app in the development mode.\
Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
The page will reload when you make changes.

### `npm run cypress`

#### Issues
Need to add new endpoints to network request tests once we implement Router


#### Type of Change:
- [] Bug fix (non-breaking change which fixes an issue)
- [] Refactor (code is working and without bugs, formatting has been streamlined)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
What steps have you taken to ensure the code is effective?
- [x] Have you used Dev Tools/ ran code in the console?
- [x] Have you verified changes using `open index.html`?

#### Checklist:
- [x] My code follows the style guidelines of this project.
- [x] My commit messages are consistent, descriptive, concise and begin with a verb and capital letter.
- [x] I have performed a self-review of my own code.
- [x] I have added reviewers.